### PR TITLE
make unchecked exception handling data output configurable

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -31,6 +31,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.eclipse.microprofile.config</groupId>
+      <artifactId>microprofile-config-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
     </dependency>

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -55,6 +55,12 @@
         <scope>test</scope>
         <version>4.11</version>
     </dependency>
+    <dependency>
+    	<groupId>org.hamcrest</groupId>
+    	<artifactId>hamcrest-library</artifactId>
+    	<scope>test</scope>
+    	<version>1.3</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -66,6 +67,11 @@ public class SmallRyeHealthReporter {
         return getRootCause(cause);
     }
 
+    @Produces
+    public static UncheckedExceptionDataStyle getDefaultUncheckedExceptionDataStyle() {
+        return UncheckedExceptionDataStyle.ROOT_CAUSE;
+    }
+    
 	/**
      * can be {@code null} if SmallRyeHealthReporter is used in a non-CDI environment
      */
@@ -75,7 +81,7 @@ public class SmallRyeHealthReporter {
     
     @Inject
     @ConfigProperty(name = "io.smallrye.health.uncheckedExceptionDataStyle", defaultValue = "ROOT_CAUSE")
-    private UncheckedExceptionDataStyle uncheckedExceptionDataStyle = UncheckedExceptionDataStyle.ROOT_CAUSE;
+    private UncheckedExceptionDataStyle uncheckedExceptionDataStyle = getDefaultUncheckedExceptionDataStyle();
 
     private List<HealthCheck> additionalChecks = new ArrayList<>();
     
@@ -84,7 +90,7 @@ public class SmallRyeHealthReporter {
 	}
     
     public void setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle uncheckedExceptionDataStyle)	{
-	    this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? UncheckedExceptionDataStyle.ROOT_CAUSE : uncheckedExceptionDataStyle;
+	    this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? getDefaultUncheckedExceptionDataStyle() : uncheckedExceptionDataStyle;
 	}
 
     public void reportHealth(OutputStream out, SmallRyeHealth health) {

--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -29,39 +29,39 @@ import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 
 @ApplicationScoped
 public class SmallRyeHealthReporter {
-	public static enum UncheckedExceptionDataStyle {
-	    NONE(null),
-	    ROOT_CAUSE("rootCause"),
-	    STACK_TRACE("stackTrace");
+    public static enum UncheckedExceptionDataStyle {
+        NONE(null),
+        ROOT_CAUSE("rootCause"),
+        STACK_TRACE("stackTrace");
         
-	    private final String dataKey;
-	    
-	    private UncheckedExceptionDataStyle(String dataKey) {
-	        this.dataKey = dataKey;
-	    }
-	    
-	    public String getDataKey() {
-		    return dataKey;
-		}
-	}
-	
+        private final String dataKey;
+        
+        private UncheckedExceptionDataStyle(String dataKey) {
+            this.dataKey = dataKey;
+        }
+        
+        public String getDataKey() {
+            return dataKey;
+        }
+    }
+    
     private static final Map<String, ?> JSON_CONFIG = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
 
     private static String getStackTrace(Throwable t) {
-	    StringWriter string = new StringWriter();
-	    
-	    try (PrintWriter pw = new PrintWriter(string)) {
-	        t.printStackTrace(pw);
-	    }
-	    
-	    return string.toString();
-	}
+        StringWriter string = new StringWriter();
+        
+        try (PrintWriter pw = new PrintWriter(string)) {
+            t.printStackTrace(pw);
+        }
+        
+        return string.toString();
+    }
     
     private static Throwable getRootCause(Throwable t) {
         Throwable cause = t.getCause();
         
         if (cause == null || cause == t) {
-        	return t;
+            return t;
         }
         
         return getRootCause(cause);
@@ -72,7 +72,7 @@ public class SmallRyeHealthReporter {
         return UncheckedExceptionDataStyle.ROOT_CAUSE;
     }
     
-	/**
+    /**
      * can be {@code null} if SmallRyeHealthReporter is used in a non-CDI environment
      */
     @Inject
@@ -86,12 +86,12 @@ public class SmallRyeHealthReporter {
     private List<HealthCheck> additionalChecks = new ArrayList<>();
     
     public UncheckedExceptionDataStyle getUncheckedExceptionDataStyle() {
-	    return uncheckedExceptionDataStyle;
-	}
+        return uncheckedExceptionDataStyle;
+    }
     
-    public void setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle uncheckedExceptionDataStyle)	{
-	    this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? getDefaultUncheckedExceptionDataStyle() : uncheckedExceptionDataStyle;
-	}
+    public void setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle uncheckedExceptionDataStyle) {
+        this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? getDefaultUncheckedExceptionDataStyle() : uncheckedExceptionDataStyle;
+    }
 
     public void reportHealth(OutputStream out, SmallRyeHealth health) {
 
@@ -149,8 +149,8 @@ public class SmallRyeHealthReporter {
             
             switch (uncheckedExceptionDataStyle) {
                 case ROOT_CAUSE:
-                	response.withData(uncheckedExceptionDataStyle.getDataKey(), getRootCause(e).getMessage());
-                	break;
+                    response.withData(uncheckedExceptionDataStyle.getDataKey(), getRootCause(e).getMessage());
+                    break;
                 case STACK_TRACE:
                     response.withData(uncheckedExceptionDataStyle.getDataKey(), getStackTrace(e));
                     break;
@@ -158,7 +158,7 @@ public class SmallRyeHealthReporter {
                     // don't add anything
             }
             
-        	return jsonObject(response.build());
+            return jsonObject(response.build());
         }
     }
 

--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -19,13 +19,31 @@ import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import javax.json.stream.JsonGenerator;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 
 
 @ApplicationScoped
 public class SmallRyeHealthReporter {
+	public static enum UncheckedExceptionDataStyle {
+	    NONE(null),
+	    ROOT_CAUSE("rootCause"),
+	    STACK_TRACE("stackTrace");
+        
+	    private final String dataKey;
+	    
+	    private UncheckedExceptionDataStyle(String dataKey) {
+	        this.dataKey = dataKey;
+	    }
+	    
+	    public String getDataKey() {
+		    return dataKey;
+		}
+	}
+	
     private static final Map<String, ?> JSON_CONFIG = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
 
     private static String getStackTrace(Throwable t) {
@@ -37,6 +55,16 @@ public class SmallRyeHealthReporter {
 	    
 	    return string.toString();
 	}
+    
+    private static Throwable getRootCause(Throwable t) {
+        Throwable cause = t.getCause();
+        
+        if (cause == null || cause == t) {
+        	return t;
+        }
+        
+        return getRootCause(cause);
+    }
 
 	/**
      * can be {@code null} if SmallRyeHealthReporter is used in a non-CDI environment
@@ -44,8 +72,20 @@ public class SmallRyeHealthReporter {
     @Inject
     @Health
     private Instance<HealthCheck> checks;
+    
+    @Inject
+    @ConfigProperty(name = "io.smallrye.health.uncheckedExceptionDataStyle", defaultValue = "ROOT_CAUSE")
+    private UncheckedExceptionDataStyle uncheckedExceptionDataStyle = UncheckedExceptionDataStyle.ROOT_CAUSE;
 
     private List<HealthCheck> additionalChecks = new ArrayList<>();
+    
+    public UncheckedExceptionDataStyle getUncheckedExceptionDataStyle() {
+	    return uncheckedExceptionDataStyle;
+	}
+    
+    public void setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle uncheckedExceptionDataStyle)	{
+	    this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? UncheckedExceptionDataStyle.ROOT_CAUSE : uncheckedExceptionDataStyle;
+	}
 
     public void reportHealth(OutputStream out, SmallRyeHealth health) {
 
@@ -99,10 +139,20 @@ public class SmallRyeHealthReporter {
         try {
             return jsonObject(check.call());
         } catch (RuntimeException e) {
-            return jsonObject(HealthCheckResponse.named(check.getClass().getName())
-                                                 .withData("stacktrace", getStackTrace(e))
-                                                 .down()
-                                                 .build());
+            HealthCheckResponseBuilder response = HealthCheckResponse.named(check.getClass().getName()).down();
+            
+            switch (uncheckedExceptionDataStyle) {
+                case ROOT_CAUSE:
+                	response.withData(uncheckedExceptionDataStyle.getDataKey(), getRootCause(e).getMessage());
+                	break;
+                case STACK_TRACE:
+                    response.withData(uncheckedExceptionDataStyle.getDataKey(), getStackTrace(e));
+                    break;
+                default:
+                    // don't add anything
+            }
+            
+        	return jsonObject(response.build());
         }
     }
 

--- a/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
+++ b/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
@@ -1,0 +1,162 @@
+package io.smallrye.health;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.Test;
+
+import io.smallrye.health.SmallRyeHealthReporter.UncheckedExceptionDataStyle;
+
+public class SmallRyeHealthReporterTest {
+    public static class FailingHealthCheck
+    implements HealthCheck {
+        @Override
+        public HealthCheckResponse call() {
+            throw new RuntimeException("this health check has failed");
+        }
+    }
+	
+    public static class DownHealthCheck
+    implements HealthCheck {
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.named("down").down().build();
+        }
+    }
+	
+    public static class UpHealthCheck
+    implements HealthCheck {
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.named("up").up().build();
+        }
+    }
+	
+	@Test
+    public void testDefaultGetHealth() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(false));
+        assertThat(health.getPayload().getString("outcome"), is("UP"));
+        assertThat(health.getPayload().getJsonArray("checks"), is(empty()));
+    }
+	
+	@Test
+    public void testGetHealthWithFailingCheckAndStyleDefault() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        reporter.addHealthCheck(new FailingHealthCheck());
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(true));
+        assertThat(health.getPayload().getString("outcome"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is(FailingHealthCheck.class.getName()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data").getString("rootCause"), is("this health check has failed"));
+    }
+	
+	@Test
+    public void testGetHealthWithFailingCheckAndStyleNone() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        reporter.addHealthCheck(new FailingHealthCheck());
+        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.NONE);
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(true));
+        assertThat(health.getPayload().getString("outcome"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is(FailingHealthCheck.class.getName()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data"), is(nullValue()));
+    }
+	
+	@Test
+    public void testGetHealthWithFailingCheckAndStyleStackTrace() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        reporter.addHealthCheck(new FailingHealthCheck());
+        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.STACK_TRACE);
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(true));
+        assertThat(health.getPayload().getString("outcome"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is(FailingHealthCheck.class.getName()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data").getString("stackTrace"), is(notNullValue()));
+    }
+
+	@Test
+    public void testGetHealthWithMixedChecksAndStyleDefault() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        reporter.addHealthCheck(new UpHealthCheck());
+        reporter.addHealthCheck(new FailingHealthCheck());
+        reporter.addHealthCheck(new DownHealthCheck());
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(true));
+        assertThat(health.getPayload().getString("outcome"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is("up"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("UP"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getString("name"), is(FailingHealthCheck.class.getName()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getString("state"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getJsonObject("data").getString("rootCause"), is("this health check has failed"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("state"), is("DOWN"));
+    }
+	
+	@Test
+    public void testGetHealthWithMixedChecksAndStyleNone() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        reporter.addHealthCheck(new UpHealthCheck());
+        reporter.addHealthCheck(new FailingHealthCheck());
+        reporter.addHealthCheck(new DownHealthCheck());
+        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.NONE);
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(true));
+        assertThat(health.getPayload().getString("outcome"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is("up"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("UP"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getString("name"), is(FailingHealthCheck.class.getName()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getString("state"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getJsonObject("data"), is(nullValue()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("state"), is("DOWN"));
+    }
+	
+	@Test
+    public void testGetHealthWithMixedChecksAndStyleStackTrace() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        reporter.addHealthCheck(new UpHealthCheck());
+        reporter.addHealthCheck(new FailingHealthCheck());
+        reporter.addHealthCheck(new DownHealthCheck());
+        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.STACK_TRACE);
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(true));
+        assertThat(health.getPayload().getString("outcome"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is("up"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("UP"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getString("name"), is(FailingHealthCheck.class.getName()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getString("state"), is("DOWN"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(1).getJsonObject("data").getString("stackTrace"), is(notNullValue()));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
+        assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("state"), is("DOWN"));
+    }
+}

--- a/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
+++ b/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
@@ -20,7 +20,7 @@ public class SmallRyeHealthReporterTest {
             throw new RuntimeException("this health check has failed");
         }
     }
-	
+    
     public static class DownHealthCheck
     implements HealthCheck {
         @Override
@@ -28,7 +28,7 @@ public class SmallRyeHealthReporterTest {
             return HealthCheckResponse.named("down").down().build();
         }
     }
-	
+    
     public static class UpHealthCheck
     implements HealthCheck {
         @Override
@@ -36,8 +36,8 @@ public class SmallRyeHealthReporterTest {
             return HealthCheckResponse.named("up").up().build();
         }
     }
-	
-	@Test
+    
+    @Test
     public void testDefaultGetHealth() {
         SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
         
@@ -47,8 +47,8 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getString("outcome"), is("UP"));
         assertThat(health.getPayload().getJsonArray("checks"), is(empty()));
     }
-	
-	@Test
+    
+    @Test
     public void testGetHealthWithFailingCheckAndStyleDefault() {
         SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
         
@@ -62,8 +62,8 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data").getString("rootCause"), is("this health check has failed"));
     }
-	
-	@Test
+    
+    @Test
     public void testGetHealthWithFailingCheckAndStyleNone() {
         SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
         
@@ -78,8 +78,8 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data"), is(nullValue()));
     }
-	
-	@Test
+    
+    @Test
     public void testGetHealthWithFailingCheckAndStyleStackTrace() {
         SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
         
@@ -95,7 +95,7 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data").getString("stackTrace"), is(notNullValue()));
     }
 
-	@Test
+    @Test
     public void testGetHealthWithMixedChecksAndStyleDefault() {
         SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
         
@@ -115,8 +115,8 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("state"), is("DOWN"));
     }
-	
-	@Test
+    
+    @Test
     public void testGetHealthWithMixedChecksAndStyleNone() {
         SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
         
@@ -137,8 +137,8 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("state"), is("DOWN"));
     }
-	
-	@Test
+    
+    @Test
     public void testGetHealthWithMixedChecksAndStyleStackTrace() {
         SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
         

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
   <properties>
     <version.asciidoctor.plugin>1.5.6</version.asciidoctor.plugin>
+    <version.eclipse.microprofile.config>1.3</version.eclipse.microprofile.config>
     <version.eclipse.microprofile.health>1.0</version.eclipse.microprofile.health>
     <version.javax.javaee-api>7.0</version.javax.javaee-api>
     <version.javax.enterprise.cdi-api>2.0</version.javax.enterprise.cdi-api>
@@ -77,6 +78,12 @@
         <groupId>org.eclipse.microprofile.health</groupId>
         <artifactId>microprofile-health-tck</artifactId>
         <version>${version.eclipse.microprofile.health}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.eclipse.microprofile.config</groupId>
+        <artifactId>microprofile-config-api</artifactId>
+        <version>${version.eclipse.microprofile.config}</version>
       </dependency>
       
       <dependency>


### PR DESCRIPTION
This PR introduces a dependency on MicroProfile Config 1.3 and adds the ability to configure the data payload for unchecked exception handling.

By default a `rootCause` data element is added with the message of the root exception.

the `io.smallrye.health.uncheckedExceptionDataStyle` config property can be set to one of `NONE`, `ROOT_CAUSE`, or `STACK_TRACE`

- `NONE` produces no data payload
- `ROOT_CAUSE` matches the default noted above
- `STACK_TRACE` adds a `stackTrace` element containing the stack trace of the unchecked exception thrown by the health check