### PR TITLE
make empty checks outcome configurable

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -49,6 +49,18 @@ public class SmallRyeHealthReporter {
     
     private static final Map<String, ?> JSON_CONFIG = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
 
+    /*
+     * the following two constants should not need to be annotated with @Produces
+     * but the TCK fails to bootstrap if @Default instances of each corresponding
+     * enum are not available
+     */
+
+    @Produces
+    public static final UncheckedExceptionDataStyle DEFAULT_UNCHECKED_EXCEPTION_DATA_STYLE = UncheckedExceptionDataStyle.ROOT_CAUSE;
+
+    @Produces
+    public static final State DEFAULT_EMPTY_CHECKS_OUTCOME = State.UP;
+
     private static String getStackTrace(Throwable t) {
         StringWriter string = new StringWriter();
         
@@ -69,16 +81,6 @@ public class SmallRyeHealthReporter {
         return getRootCause(cause);
     }
 
-    @Produces
-    public static UncheckedExceptionDataStyle getDefaultUncheckedExceptionDataStyle() {
-        return UncheckedExceptionDataStyle.ROOT_CAUSE;
-    }
-
-    @Produces
-    public static State getDefaultEmptyChecksOutcome() {
-        return State.UP;
-    }
-    
     /**
      * can be {@code null} if SmallRyeHealthReporter is used in a non-CDI environment
      */
@@ -88,11 +90,11 @@ public class SmallRyeHealthReporter {
     
     @Inject
     @ConfigProperty(name = "io.smallrye.health.uncheckedExceptionDataStyle", defaultValue = "ROOT_CAUSE")
-    private UncheckedExceptionDataStyle uncheckedExceptionDataStyle = getDefaultUncheckedExceptionDataStyle();
+    private UncheckedExceptionDataStyle uncheckedExceptionDataStyle = DEFAULT_UNCHECKED_EXCEPTION_DATA_STYLE;
     
     @Inject
     @ConfigProperty(name = "io.smallrye.health.emptyChecksOutcome", defaultValue = "UP")
-    private State emptyChecksOutcome = getDefaultEmptyChecksOutcome();
+    private State emptyChecksOutcome = DEFAULT_EMPTY_CHECKS_OUTCOME;
 
     private List<HealthCheck> additionalChecks = new ArrayList<>();
     
@@ -101,7 +103,7 @@ public class SmallRyeHealthReporter {
     }
     
     public void setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle uncheckedExceptionDataStyle) {
-        this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? getDefaultUncheckedExceptionDataStyle() : uncheckedExceptionDataStyle;
+        this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? DEFAULT_UNCHECKED_EXCEPTION_DATA_STYLE : uncheckedExceptionDataStyle;
     }
 
     public State getEmptyChecksOutcome() {
@@ -109,7 +111,7 @@ public class SmallRyeHealthReporter {
     }
     
     public void setEmptyChecksOutcome(State emptyChecksOutcome) {
-        this.emptyChecksOutcome = emptyChecksOutcome;
+        this.emptyChecksOutcome = emptyChecksOutcome == null ? DEFAULT_EMPTY_CHECKS_OUTCOME : emptyChecksOutcome;
     }
     
     public void reportHealth(OutputStream out, SmallRyeHealth health) {

--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -104,6 +104,14 @@ public class SmallRyeHealthReporter {
         this.uncheckedExceptionDataStyle = uncheckedExceptionDataStyle == null ? getDefaultUncheckedExceptionDataStyle() : uncheckedExceptionDataStyle;
     }
 
+    public State getEmptyChecksOutcome() {
+        return emptyChecksOutcome;
+    }
+    
+    public void setEmptyChecksOutcome(State emptyChecksOutcome) {
+        this.emptyChecksOutcome = emptyChecksOutcome;
+    }
+    
     public void reportHealth(OutputStream out, SmallRyeHealth health) {
 
         JsonWriterFactory factory = Json.createWriterFactory(JSON_CONFIG);

--- a/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
+++ b/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertThat;
 
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponse.State;
 import org.junit.Test;
 
 import io.smallrye.health.SmallRyeHealthReporter.UncheckedExceptionDataStyle;
@@ -45,6 +46,19 @@ public class SmallRyeHealthReporterTest {
         
         assertThat(health.isDown(), is(false));
         assertThat(health.getPayload().getString("outcome"), is("UP"));
+        assertThat(health.getPayload().getJsonArray("checks"), is(empty()));
+    }
+    
+    @Test
+    public void testGetHealthWithEmptyChecksOutcomeDown() {
+        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
+        
+        reporter.setEmptyChecksOutcome(State.DOWN);
+        
+        SmallRyeHealth health = reporter.getHealth();
+        
+        assertThat(health.isDown(), is(true));
+        assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks"), is(empty()));
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,9 @@
     <version.weld>2.4.7.Final</version.weld>
     <version.arquillian.wildfly>2.1.0.Final</version.arquillian.wildfly>
     <version.wildfly>13.0.0.Final</version.wildfly>
-    <version.jboss.servlet>1.0.0.Final</version.jboss.servlet> 
+    <version.jboss.servlet>1.0.0.Final</version.jboss.servlet>
     <version.javax-json>1.1.2</version.javax-json>
+    <version.smallrye-config>1.3.3</version.smallrye-config>
   </properties>
 
   <scm>
@@ -79,23 +80,23 @@
         <artifactId>microprofile-health-tck</artifactId>
         <version>${version.eclipse.microprofile.health}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
         <version>${version.eclipse.microprofile.config}</version>
       </dependency>
-      
+
       <dependency>
-         <groupId>org.glassfish</groupId>
-         <artifactId>javax.json</artifactId>
-         <version>${version.javax-json}</version>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.json</artifactId>
+        <version>${version.javax-json}</version>
       </dependency>
 
       <dependency>
-         <groupId>org.jboss.spec.javax.servlet</groupId>
-         <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-         <version>${version.jboss.servlet}</version>
+        <groupId>org.jboss.spec.javax.servlet</groupId>
+        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+        <version>${version.jboss.servlet}</version>
       </dependency>
 
       <!-- Other dependencies -->
@@ -104,13 +105,13 @@
         <artifactId>cdi-api</artifactId>
         <version>${version.javax.enterprise.cdi-api}</version>
       </dependency>
-      
+
       <dependency>
-         <groupId>org.jboss.arquillian</groupId>
-         <artifactId>arquillian-bom</artifactId>
-         <version>${version.org.jboss.arquillian}</version>
-         <scope>import</scope>
-         <type>pom</type>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.org.jboss.arquillian}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <dependency>
@@ -125,6 +126,12 @@
         <artifactId>weld-servlet-core</artifactId>
         <version>${version.weld}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-config</artifactId>
+        <version>${version.smallrye-config}</version>
       </dependency>
 
       <!-- Dependencies provided by the project -->

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -42,6 +42,7 @@
       </plugin>
     </plugins>
   </build>
+
   <dependencies>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
@@ -69,27 +70,36 @@
       <artifactId>shrinkwrap-resolver-depchain</artifactId>
       <type>pom</type>
     </dependency>
+
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-config</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>javax.json</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-tck</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-         <groupId>org.jboss.arquillian.testng</groupId>
-         <artifactId>arquillian-testng-container</artifactId>
-         <version>${version.org.jboss.arquillian}</version>
-         <scope>test</scope>
+      <groupId>org.jboss.arquillian.testng</groupId>
+      <artifactId>arquillian-testng-container</artifactId>
+      <scope>test</scope>
     </dependency>
- 
+
   </dependencies>
+
   <profiles>
     <profile>
       <id>wildfly-servlet</id>

--- a/tck/src/test/java/io/smallrye/health/SmallRyeHealthArchiveProcessor.java
+++ b/tck/src/test/java/io/smallrye/health/SmallRyeHealthArchiveProcessor.java
@@ -33,13 +33,14 @@ public class SmallRyeHealthArchiveProcessor implements ApplicationArchiveProcess
             // Register SmallRyeBeanArchiveHandler using the ServiceLoader mechanism
             testDeployment.addClass(SmallRyeBeanArchiveHandler.class);
             testDeployment.addAsServiceProvider(BeanArchiveHandler.class, SmallRyeBeanArchiveHandler.class);
-            
-            String[] deps = { 
+
+            String[] deps = {
                 "io.smallrye:smallrye-health",
+                "io.smallrye:smallrye-config",
                 "io.smallrye:smallrye-health-tck",
                 "org.eclipse.microprofile.health:microprofile-health-tck",
                 "org.jboss.weld.servlet:weld-servlet-core" };
-    
+
             File[] dependencies = Maven.resolver().loadPomFromFile(new File("pom.xml")).resolve(deps).withTransitivity().asFile();
 
             testDeployment.addAsLibraries(dependencies);


### PR DESCRIPTION
Per https://github.com/eclipse/microprofile-health/issues/138, this PR enables setting the desired outcome when no health checks are installed. Default behavior is preserved to return `UP`. Setting `io.smallrye.health.emptyChecksOutcome=DOWN` will override the default.