### PR TITLE
chore: fixed unrecommended usage of private members

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -77,15 +77,15 @@ public class SmallRyeHealthReporter {
      */
     @Inject
     @Health
-    private Instance<HealthCheck> checks;
+    Instance<HealthCheck> checks;
 
     @Inject
     @ConfigProperty(name = "io.smallrye.health.uncheckedExceptionDataStyle", defaultValue = "ROOT_CAUSE")
-    private UncheckedExceptionDataStyle uncheckedExceptionDataStyle = DEFAULT_UNCHECKED_EXCEPTION_DATA_STYLE;
+    UncheckedExceptionDataStyle uncheckedExceptionDataStyle = DEFAULT_UNCHECKED_EXCEPTION_DATA_STYLE;
 
     @Inject
     @ConfigProperty(name = "io.smallrye.health.emptyChecksOutcome", defaultValue = "UP")
-    private State emptyChecksOutcome = DEFAULT_EMPTY_CHECKS_OUTCOME;
+    State emptyChecksOutcome = DEFAULT_EMPTY_CHECKS_OUTCOME;
 
     private List<HealthCheck> additionalChecks = new ArrayList<>();
 


### PR DESCRIPTION
This fixes the warnings seen in Quarkus:
```
19:10:34.954 [build-4] DEBUG io.quarkus.arc.processor.BeanProcessor - Found unrecommended usage of private members (use package-private instead) in framework beans:
	- @Inject field io.smallrye.health.SmallRyeHealthReporter#checks,
```