### PR TITLE
Fixes #28

### DIFF
--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -39,6 +39,12 @@
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
@@ -49,6 +55,7 @@
       <artifactId>javax.json</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/implementation/src/main/java/io/smallrye/health/ResponseBuilder.java
+++ b/implementation/src/main/java/io/smallrye/health/ResponseBuilder.java
@@ -55,6 +55,10 @@ class ResponseBuilder extends HealthCheckResponseBuilder {
 
     @Override
     public HealthCheckResponse build() {
+        if (null == this.name || this.name.trim().length() == 0) {
+            throw new IllegalArgumentException("Health Check contains an invalid name. Can not be null or empty.");
+        }
+
         return new Response(this.name, this.state, this.data.isEmpty() ? null : this.data);
     }
 

--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -25,10 +25,13 @@ import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.jboss.logging.Logger;
 
 
 @ApplicationScoped
 public class SmallRyeHealthReporter {
+    private static Logger LOG = Logger.getLogger(SmallRyeHealthReporter.class);
+
     private static final String ROOT_CAUSE = "rootCause";
 
     private static final String STACK_TRACE = "stackTrace";
@@ -117,8 +120,8 @@ public class SmallRyeHealthReporter {
         try {
             return jsonObject(check.call());
         } catch (RuntimeException e) {
-            // Print Stacktrace to server log so an error is not just in Health Check response
-            e.printStackTrace();
+            // Log Stacktrace to server log so an error is not just in Health Check response
+            LOG.error("Error processing Health Checks", e);
 
             HealthCheckResponseBuilder response = HealthCheckResponse.named(check.getClass().getName()).down();
 

--- a/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
+++ b/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
@@ -9,99 +9,95 @@ import static org.junit.Assert.assertThat;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponse.State;
+import org.junit.Before;
 import org.junit.Test;
 
-import io.smallrye.health.SmallRyeHealthReporter.UncheckedExceptionDataStyle;
-
 public class SmallRyeHealthReporterTest {
-    public static class FailingHealthCheck
-    implements HealthCheck {
+
+    private SmallRyeHealthReporter reporter;
+
+    public static class FailingHealthCheck implements HealthCheck {
         @Override
         public HealthCheckResponse call() {
             throw new RuntimeException("this health check has failed");
         }
     }
-    
-    public static class DownHealthCheck
-    implements HealthCheck {
+
+    public static class DownHealthCheck implements HealthCheck {
         @Override
         public HealthCheckResponse call() {
             return HealthCheckResponse.named("down").down().build();
         }
     }
-    
-    public static class UpHealthCheck
-    implements HealthCheck {
+
+    public static class UpHealthCheck implements HealthCheck {
         @Override
         public HealthCheckResponse call() {
             return HealthCheckResponse.named("up").up().build();
         }
     }
-    
+
+    @Before
+    public void createReporter() {
+        reporter = new SmallRyeHealthReporter();
+        reporter.emptyChecksOutcome = "UP";
+        reporter.uncheckedExceptionDataStyle = "rootCause";
+    }
+
     @Test
     public void testDefaultGetHealth() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(false));
         assertThat(health.getPayload().getString("outcome"), is("UP"));
         assertThat(health.getPayload().getJsonArray("checks"), is(empty()));
     }
-    
+
     @Test
     public void testGetHealthWithEmptyChecksOutcomeDown() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
-        reporter.setEmptyChecksOutcome(State.DOWN);
-        
+        reporter.setEmptyChecksOutcome(State.DOWN.toString());
+
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(true));
         assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks"), is(empty()));
     }
-    
+
     @Test
     public void testGetHealthWithFailingCheckAndStyleDefault() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
         reporter.addHealthCheck(new FailingHealthCheck());
-        
+
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(true));
         assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is(FailingHealthCheck.class.getName()));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data").getString("rootCause"), is("this health check has failed"));
     }
-    
+
     @Test
     public void testGetHealthWithFailingCheckAndStyleNone() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
         reporter.addHealthCheck(new FailingHealthCheck());
-        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.NONE);
-        
+        reporter.setUncheckedExceptionDataStyle("NONE");
+
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(true));
         assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is(FailingHealthCheck.class.getName()));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("state"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getJsonObject("data"), is(nullValue()));
     }
-    
+
     @Test
     public void testGetHealthWithFailingCheckAndStyleStackTrace() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
         reporter.addHealthCheck(new FailingHealthCheck());
-        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.STACK_TRACE);
-        
+        reporter.setUncheckedExceptionDataStyle("stackTrace");
+
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(true));
         assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is(FailingHealthCheck.class.getName()));
@@ -111,14 +107,12 @@ public class SmallRyeHealthReporterTest {
 
     @Test
     public void testGetHealthWithMixedChecksAndStyleDefault() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
         reporter.addHealthCheck(new UpHealthCheck());
         reporter.addHealthCheck(new FailingHealthCheck());
         reporter.addHealthCheck(new DownHealthCheck());
-        
+
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(true));
         assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is("up"));
@@ -129,18 +123,16 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("state"), is("DOWN"));
     }
-    
+
     @Test
     public void testGetHealthWithMixedChecksAndStyleNone() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
         reporter.addHealthCheck(new UpHealthCheck());
         reporter.addHealthCheck(new FailingHealthCheck());
         reporter.addHealthCheck(new DownHealthCheck());
-        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.NONE);
-        
+        reporter.setUncheckedExceptionDataStyle("NONE");
+
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(true));
         assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is("up"));
@@ -151,18 +143,16 @@ public class SmallRyeHealthReporterTest {
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("state"), is("DOWN"));
     }
-    
+
     @Test
     public void testGetHealthWithMixedChecksAndStyleStackTrace() {
-        SmallRyeHealthReporter reporter = new SmallRyeHealthReporter();
-        
         reporter.addHealthCheck(new UpHealthCheck());
         reporter.addHealthCheck(new FailingHealthCheck());
         reporter.addHealthCheck(new DownHealthCheck());
-        reporter.setUncheckedExceptionDataStyle(UncheckedExceptionDataStyle.STACK_TRACE);
-        
+        reporter.setUncheckedExceptionDataStyle("stackTrace");
+
         SmallRyeHealth health = reporter.getHealth();
-        
+
         assertThat(health.isDown(), is(true));
         assertThat(health.getPayload().getString("outcome"), is("DOWN"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(0).getString("name"), is("up"));

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <version.jboss.servlet>1.0.2.Final</version.jboss.servlet>
     <version.javax-json>1.1.4</version.javax-json>
     <version.smallrye-config>1.3.5</version.smallrye-config>
+    <version.jboss-logging>3.4.0.Final</version.jboss-logging>
   </properties>
 
   <scm>
@@ -99,11 +100,16 @@
         <version>${version.jboss.servlet}</version>
       </dependency>
 
-      <!-- Other dependencies -->
       <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
         <version>${version.javax.enterprise.cdi-api}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>${version.jboss-logging}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
 - Throw an exception with meaningful message when Health Check doesn't have a name defined
 - Rework the exception handling when processing Health Checks so that messages are logged to the server console, as well as returned to the Health endpoint
 - Rework how the Config property values are defined in the Reporter