### PR TITLE
Update to Jakarta EE 8 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,34 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>org.eclipse.microprofile.health</groupId>
         <artifactId>microprofile-health-tck</artifactId>
         <version>${version.eclipse.microprofile.health}</version>
+        <exclusions>
+          <exclusion>
+            <groupId> javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.mail</groupId>
+            <artifactId>mailapi</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -102,6 +124,12 @@
         <artifactId>weld-servlet-core</artifactId>
         <version>${version.weld.core}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -85,6 +85,12 @@
       <groupId>org.jboss.shrinkwrap.resolver</groupId>
       <artifactId>shrinkwrap-resolver-depchain</artifactId>
       <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -116,6 +122,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- required for the TCK, remove when the MP Health moves to Jakarta artifacts -->
+    <dependency>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>jakarta.mail</artifactId>
+      <version>1.6.4</version>
+    </dependency>
+
   </dependencies>
 
   <profiles>
@@ -132,6 +145,12 @@
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
           <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>javax.inject</groupId>
+              <artifactId>javax.inject</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
`mvn dependency:tree | grep javax`

```
[INFO] |  |     +- org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec:jar:2.0.1.Final:compile
[INFO] |  |     \- org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec:jar:2.0.0.Final:compile
[INFO] |  +- org.jboss.spec.javax.el:jboss-el-api_3.0_spec:jar:2.0.0.Final:compile
[INFO] |  +- org.glassfish:javax.json:jar:1.0:test
```