### PR TITLE
Log health down reasons when reporting

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -87,6 +87,10 @@ public class SmallRyeHealthReporter {
     }
 
     public void reportHealth(OutputStream out, SmallRyeHealth health) {
+        if (health.isDown() && LOG.isInfoEnabled()) {
+            // Log reason, as not reported by container orchestrators, yet container may get killed.
+            LOG.infov("Reporting health down status: {0}", health.getPayload());
+        }
 
         JsonWriterFactory factory = jsonProvider.createWriterFactory(JSON_CONFIG);
         JsonWriter writer = factory.createWriter(out);
@@ -259,5 +263,5 @@ public class SmallRyeHealthReporter {
 
         return getRootCause(cause);
     }
-    
+
 }

--- a/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
+++ b/implementation/src/test/java/io/smallrye/health/SmallRyeHealthReporterTest.java
@@ -1,10 +1,17 @@
 package io.smallrye.health;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
 
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -172,5 +179,18 @@ public class SmallRyeHealthReporterTest {
                 is(notNullValue()));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("name"), is("down"));
         assertThat(health.getPayload().getJsonArray("checks").getJsonObject(2).getString("status"), is("DOWN"));
+    }
+
+    @Test
+    public void testReportWhenDown() {
+        ByteArrayOutputStream logStream = new ByteArrayOutputStream();
+        Handler handler = new StreamHandler(logStream, new SimpleFormatter());
+        Logger.getLogger(SmallRyeHealthReporter.class.getName()).addHandler(handler);
+        reporter.addHealthCheck(new DownHealthCheck());
+
+        reporter.reportHealth(new ByteArrayOutputStream(), reporter.getHealth());
+
+        handler.flush();
+        assertThat(logStream.toString(), containsString(reporter.getHealth().getPayload().toString()));
     }
 }


### PR DESCRIPTION
This is a proposal for #90

SmallRyeHealthReporter#report looks like the only potential place to have such log ?
I wasn't sure of log level - health down are pretty normal during startup so can't really be ERROR. 
I used INFO to be on the conservative side (health down won't cause any traffic loss if load balanced with other replicas), but could be changed WARN.