### PR TITLE
Fix the use of mp.health.default.readiness.empty.response property

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -113,12 +113,6 @@ public class SmallRyeHealthReporter {
     @ConfigProperty(name = "io.smallrye.health.timeout.seconds", defaultValue = "60")
     int timeoutSeconds;
 
-    /* specification defined configuration values */
-
-    @Inject
-    @ConfigProperty(name = "mp.health.default.readiness.empty.response", defaultValue = "DOWN")
-    String mpHealthDefaultReadinessEmptyResponse;
-
     @Inject
     AsyncHealthCheckFactory asyncHealthCheckFactory;
 
@@ -222,11 +216,6 @@ public class SmallRyeHealthReporter {
 
     @Experimental("Asynchronous Health Check procedures")
     public Uni<SmallRyeHealth> getReadinessAsync() {
-        if (readinessUnis != null && readinessUnis.isEmpty() &&
-                readinessHealthRegistry.getChecks() != null && readinessHealthRegistry.getChecks().isEmpty()) {
-            return Uni.createFrom().item(createEmptySmallRyeHealth(mpHealthDefaultReadinessEmptyResponse));
-        }
-
         return getHealthAsync(smallRyeReadinessUni, READINESS);
     }
 

--- a/implementation/src/test/java/io/smallrye/health/HealthRegistryTest.java
+++ b/implementation/src/test/java/io/smallrye/health/HealthRegistryTest.java
@@ -37,7 +37,6 @@ public class HealthRegistryTest {
         livenessHealthRegistry.setAsyncHealthCheckFactory(asyncHealthCheckFactory);
         readinessHealthRegistry.setAsyncHealthCheckFactory(asyncHealthCheckFactory);
         reporter.setEmptyChecksOutcome(HealthCheckResponse.Status.UP.toString());
-        reporter.mpHealthDefaultReadinessEmptyResponse = HealthCheckResponse.Status.UP.toString();
         reporter.livenessHealthRegistry = livenessHealthRegistry;
         reporter.readinessHealthRegistry = readinessHealthRegistry;
         reporter.timeoutSeconds = 60;


### PR DESCRIPTION
This property should only be used before we have the knowledge of the user-defined checks. As `SmallRyeHealthReporter` will be always initialized before the call to getReadinessAsync can be processed there is no way that we can use this property. It must be handled in the runtime that is including SR Health and have issues with `/health/ready` responding sooner than the `SmallRyeHealthReporter` is able to respond.