### PR TITLE
(3.0.x) Fix the use of mp.health.default.readiness.empty.response property

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -113,12 +113,6 @@ public class SmallRyeHealthReporter {
     @ConfigProperty(name = "io.smallrye.health.timeout.seconds", defaultValue = "60")
     int timeoutSeconds;
 
-    /* specification defined configuration values */
-
-    @Inject
-    @ConfigProperty(name = "mp.health.default.readiness.empty.response", defaultValue = "DOWN")
-    String mpHealthDefaultReadinessEmptyResponse;
-
     @Inject
     AsyncHealthCheckFactory asyncHealthCheckFactory;
 
@@ -218,11 +212,6 @@ public class SmallRyeHealthReporter {
 
     @Experimental("Asynchronous Health Check procedures")
     public Uni<SmallRyeHealth> getReadinessAsync() {
-        if (readinessUnis != null && readinessUnis.isEmpty() &&
-                readinessHealthRegistry.getChecks() != null && readinessHealthRegistry.getChecks().isEmpty()) {
-            return Uni.createFrom().item(createEmptySmallRyeHealth(mpHealthDefaultReadinessEmptyResponse));
-        }
-
         return getHealthAsync(smallRyeReadinessUni, READINESS);
     }
 

--- a/implementation/src/test/java/io/smallrye/health/HealthRegistryTest.java
+++ b/implementation/src/test/java/io/smallrye/health/HealthRegistryTest.java
@@ -37,7 +37,6 @@ public class HealthRegistryTest {
         livenessHealthRegistry.setAsyncHealthCheckFactory(asyncHealthCheckFactory);
         readinessHealthRegistry.setAsyncHealthCheckFactory(asyncHealthCheckFactory);
         reporter.setEmptyChecksOutcome(HealthCheckResponse.Status.UP.toString());
-        reporter.mpHealthDefaultReadinessEmptyResponse = HealthCheckResponse.Status.UP.toString();
         reporter.livenessHealthRegistry = livenessHealthRegistry;
         reporter.readinessHealthRegistry = readinessHealthRegistry;
         reporter.timeoutSeconds = 60;


### PR DESCRIPTION
Backport of https://github.com/smallrye/smallrye-health/pull/246 to the 3.0.x branch.