### PR TITLE
Add property for context propagation to the health checks

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -21,6 +21,7 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
@@ -50,6 +51,10 @@ import io.smallrye.mutiny.Uni;
 public class SmallRyeHealthReporter {
 
     private static final Map<String, ?> JSON_CONFIG = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
+
+    @Inject
+    @ConfigProperty(name = "io.smallrye.health.context.propagation", defaultValue = "false")
+    boolean contextPropagated;
 
     /**
      * can be {@code null} if SmallRyeHealthReporter is used in a non-CDI environment
@@ -269,12 +274,26 @@ public class SmallRyeHealthReporter {
     }
 
     private Uni<SmallRyeHealth> getHealthAsync(Uni<SmallRyeHealth> cachedHealth, HealthType... types) {
-        if (additionalListsChanged(types) || additionalListsChanged || cachedHealth == null) {
-            additionalListsChanged = false;
-            cachedHealth = computeHealth(types);
-        }
+        if (contextPropagated) {
+            recreateCheckUnis();
+            return computeHealth(types);
+        } else {
+            if (additionalListsChanged(types) || additionalListsChanged || cachedHealth == null) {
+                additionalListsChanged = false;
+                cachedHealth = computeHealth(types);
+            }
 
-        return cachedHealth;
+            return cachedHealth;
+        }
+    }
+
+    private void recreateCheckUnis() {
+        livenessUnis.clear();
+        readinessUnis.clear();
+        wellnessUnis.clear();
+        startnessUnis.clear();
+
+        initChecks();
     }
 
     private boolean additionalListsChanged(HealthType... types) {


### PR DESCRIPTION
Fixes #261

The tests will be included in Quarkus. The arquillian adapter we use (WildFly) doesn't propagate requests to the different threads so it is impossible to write tests here. Required for https://github.com/quarkusio/quarkus/issues/16813.