### PR TITLE
Change comment in @HealthGroup annotation to add path "group"

### DIFF
--- a/api/src/main/java/io/smallrye/health/api/HealthGroup.java
+++ b/api/src/main/java/io/smallrye/health/api/HealthGroup.java
@@ -49,7 +49,7 @@ import io.smallrye.common.annotation.Experimental;
 @Documented
 @Qualifier
 @Repeatable(HealthGroups.class)
-@Experimental("Custom health group definitions exposed at /health/{group-name}. Not covered by the specification. " +
+@Experimental("Custom health group definitions exposed at /health/group/{group-name}. Not covered by the specification. " +
         "Subject to change.")
 public @interface HealthGroup {
 

--- a/api/src/main/java/io/smallrye/health/api/HealthGroups.java
+++ b/api/src/main/java/io/smallrye/health/api/HealthGroups.java
@@ -43,7 +43,7 @@ import io.smallrye.common.annotation.Experimental;
 @Target({ PARAMETER, FIELD, METHOD, TYPE })
 @Documented
 @Retention(RUNTIME)
-@Experimental("Custom health group definitions exposed at /health/{group-name}. Not covered by the specification. " +
+@Experimental("Custom health group definitions exposed at /health/group/{group-name}. Not covered by the specification. " +
         "Subject to change.")
 public @interface HealthGroups {
     /**


### PR DESCRIPTION
According to the documentation: https://smallrye.io/docs/smallrye-health/3.0.0/health-groups.html
The right health group endpoint is `/health/group/{group-name}`, not `/health/{group-name}`.
I'm aware that this can be configured, but at least the comment should be consistent with the default value.