### PR TITLE
Add config value for max custom group registrations

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/registry/HealthRegistries.java
+++ b/implementation/src/main/java/io/smallrye/health/registry/HealthRegistries.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.Readiness;
 import org.eclipse.microprofile.health.Startup;
@@ -19,8 +20,22 @@ import io.smallrye.health.api.Wellness;
 @ApplicationScoped
 public class HealthRegistries {
 
+    private static final int MAX_GROUP_REGISTRIES_COUNT_DEFAULT = 100;
+
     private static final Map<HealthType, HealthRegistry> registries = new ConcurrentHashMap<>();
     private static final Map<String, HealthRegistry> groupRegistries = new ConcurrentHashMap<>();
+
+    private static int maxGroupRegistriesCount = MAX_GROUP_REGISTRIES_COUNT_DEFAULT;
+
+    static {
+        try {
+            maxGroupRegistriesCount = ConfigProvider.getConfig()
+                    .getOptionalValue("io.smallrye.health.maxGroupRegistriesCount", Integer.class)
+                    .orElse(MAX_GROUP_REGISTRIES_COUNT_DEFAULT);
+        } catch (IllegalStateException illegalStateException) {
+            // OK, no config provider was found, use default values
+        }
+    }
 
     @Produces
     @Liveness
@@ -59,7 +74,17 @@ public class HealthRegistries {
             throw new IllegalArgumentException("Health group name cannot be null");
         }
 
-        return groupRegistries.computeIfAbsent(groupName, s -> new HealthRegistryImpl());
+        HealthRegistry healthRegistry = groupRegistries.get(groupName);
+        if (healthRegistry == null) {
+            if (groupRegistries.keySet().size() >= maxGroupRegistriesCount) {
+                throw new IllegalStateException(
+                        "Attempted to create more custom health group registries than allowed: " + maxGroupRegistriesCount);
+            }
+
+            healthRegistry = groupRegistries.computeIfAbsent(groupName, s -> new HealthRegistryImpl());
+        }
+
+        return healthRegistry;
     }
 
     public static Collection<HealthRegistry> getHealthGroupRegistries() {

--- a/implementation/src/test/java/io/smallrye/health/HealthRegistryTest.java
+++ b/implementation/src/test/java/io/smallrye/health/HealthRegistryTest.java
@@ -2,6 +2,7 @@ package io.smallrye.health;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -223,6 +224,21 @@ public class HealthRegistryTest {
     @Test
     public void healthGroupNullTest() {
         assertThrows(IllegalArgumentException.class, () -> HealthRegistries.getHealthGroupRegistry(null));
+    }
+
+    @Test
+    public void testMaxGroupRegistriesCreations() {
+        // default defined at HealthRegistries#MAX_GROUP_REGISTRIES_COUNT_DEFAULT = 100
+        // one group already created by previous test
+
+        for (int i = 0; i < 99; i++) {
+            HealthRegistries.getHealthGroupRegistry("healthGroup" + i);
+        }
+
+        assertEquals(100, HealthRegistries.getHealthGroupRegistries().size());
+
+        assertThrows(IllegalStateException.class,
+                () -> HealthRegistries.getHealthGroupRegistry("HealthGroup101"));
     }
 
     private void assertExpectedHealth(SmallRyeHealth health, String... healthCheckNames) {


### PR DESCRIPTION
Fixes #397 

This only introduces a mechanism to prevent potential DoS attacks since if we allow creating custom groups on demand from the outside world (which will need to be done in Quarkus or other implementations that expose health endpoints) as we might have an attack situated `for i in {1..10000}; do http :8080/q/health/group/$i; done`.