### PR TITLE
Provide elementary concurrency for SmallRyeHealthReporter

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -124,7 +124,7 @@ public class SmallRyeHealthReporter {
     private final Map<String, Uni<HealthCheckResponse>> additionalChecks = new HashMap<>();
 
     private final JsonProvider jsonProvider = JsonProvider.provider();
-    private boolean checksInitialized = false;
+    private volatile boolean checksInitialized = false;
 
     private Uni<SmallRyeHealth> smallRyeHealthUni = null;
     private Uni<SmallRyeHealth> smallRyeLivenessUni = null;
@@ -180,7 +180,10 @@ public class SmallRyeHealthReporter {
         }
     }
 
-    private void initChecks() {
+    private synchronized void initChecks() {
+        if (checksInitialized) {
+            return;
+        }
         initUnis(livenessUnis, livenessChecks, asyncLivenessChecks);
         initUnis(readinessUnis, readinessChecks, asyncReadinessChecks);
         initUnis(wellnessUnis, wellnessChecks, asyncWellnessChecks);


### PR DESCRIPTION
The methods of this class can (and are) called
concurrently by Quarkus
so there needs to be some control.

This PR provides the absolute basic form
(both in terms of coverage and in terms
of idioms used)

Relates to: https://github.com/quarkusio/quarkus/issues/32800