### PR TITLE
Limit WildFly verification for release to only MP Health test cases

### DIFF
--- a/.github/workflows/review-release.yml
+++ b/.github/workflows/review-release.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           ./mvnw clean install -DskipTests -DskipITs -Denforcer.skip -Dversion.io.smallrye.smallrye-health="$SNAPSHOT_VERSION"
           ./mvnw clean verify -pl microprofile/health-smallrye -Dversion.io.smallrye.smallrye-health="$SNAPSHOT_VERSION"
-          ./mvnw clean verify -pl testsuite/integration/microprofile -Dts.standalone.microprofile -Dversion.io.smallrye.smallrye-health="$SNAPSHOT_VERSION"
+          ./mvnw clean verify -pl testsuite/integration/microprofile -Dts.standalone.microprofile -Dtest="org.wildfly.test.integration.microprofile.health.*TestCase" -Dversion.io.smallrye.smallrye-health="$SNAPSHOT_VERSION"
           ./mvnw clean verify -pl testsuite/integration/microprofile-tck/health -Dts.standalone.microprofile -Dversion.io.smallrye.smallrye-health="$SNAPSHOT_VERSION"
           ./mvnw clean verify -pl testsuite/integration/manualmode -Dts.manualmode -Dtest="MicroProfile*" -Dversion.io.smallrye.smallrye-health="$SNAPSHOT_VERSION"
 


### PR DESCRIPTION
To avoid failures in different MP specs causing failures of SR health releases.