### PR TITLE
Move SmallRyeHealthReporter init into the post construct method

### DIFF
--- a/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
+++ b/implementation/src/main/java/io/smallrye/health/SmallRyeHealthReporter.java
@@ -143,7 +143,8 @@ public class SmallRyeHealthReporter {
     private List<Uni<HealthCheckResponse>> wellnessUnis = new CopyOnWriteArrayList<>();
     private List<Uni<HealthCheckResponse>> startupUnis = new CopyOnWriteArrayList<>();
 
-    public SmallRyeHealthReporter() {
+    @PostConstruct
+    public void postConstruct() {
         try {
             Config config = ConfigProvider.getConfig();
             contextPropagated = config
@@ -176,10 +177,7 @@ public class SmallRyeHealthReporter {
         if (asyncHealthCheckFactory == null) {
             asyncHealthCheckFactory = new AsyncHealthCheckFactory();
         }
-    }
 
-    @PostConstruct
-    public void postConstruct() {
         if (!delayHealthCheckInit) {
             initChecks();
         }

--- a/implementation/src/main/resources/META-INF/beans.xml
+++ b/implementation/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,7 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="annotated">
 </beans>

--- a/testsuite/tck/src/test/resources/META-INF/beans.xml
+++ b/testsuite/tck/src/test/resources/META-INF/beans.xml
@@ -1,5 +1,7 @@
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0"
        bean-discovery-mode="all">
 </beans>


### PR DESCRIPTION
Fixes #562

@gsmet, if you look into this, I discussed it with @mkouba, and singleton is not a good idea because of various problems, mostly in WildFly integration. But at least I moved all initialization to post-construct. 