### PR TITLE
Next is 4.3.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>smallrye-health-parent</artifactId>
     <groupId>io.smallrye</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-health-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-health</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>smallrye-health-parent</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>4.3.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>SmallRye Health: Parent</name>

--- a/provided-checks/pom.xml
+++ b/provided-checks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>smallrye-health-parent</artifactId>
     <groupId>io.smallrye</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-health-provided-checks</artifactId>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-health-parent</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>smallrye-health-release</artifactId>

--- a/testsuite/experimental/pom.xml
+++ b/testsuite/experimental/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-health-testsuite-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>smallrye-health-parent</artifactId>
     <groupId>io.smallrye</groupId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/tck/pom.xml
+++ b/testsuite/tck/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-health-testsuite-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-health-tck</artifactId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.smallrye</groupId>
     <artifactId>smallrye-health-parent</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>smallrye-health-ui</artifactId>


### PR DESCRIPTION
The breaking change is only on the experimental APIs that is marked with the `@Experimental` annotation. Thus we don't need a major release.