### PR TITLE
Add -UseContainerSupport to WFLY JVM arguments in the TCK

### DIFF
--- a/testsuite/experimental/src/test/resources/arquillian.xml
+++ b/testsuite/experimental/src/test/resources/arquillian.xml
@@ -3,12 +3,14 @@
             xsi:schemaLocation="
         http://jboss.org/schema/arquillian
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
-  <container qualifier="jbossas-managed" default="true">
-    <configuration>
-<!--      <property name="jbossHome">target/jboss-as-7.1.1.Final</property>-->
-<!--      <property name="javaVmArguments">-->
-<!--        -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y-->
-<!--      </property>-->
-    </configuration>
-  </container>
+    <container qualifier="jbossas-managed" default="true">
+        <configuration>
+            <!-- required for JDK 17 test run -->
+            <property name="javaVmArguments">-XX:-UseContainerSupport</property>
+            <!--      <property name="jbossHome">target/jboss-as-7.1.1.Final</property>-->
+            <!--      <property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m-->
+            <!--        -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y-->
+            <!--      </property>-->
+        </configuration>
+    </container>
 </arquillian>

--- a/testsuite/tck/src/test/resources/arquillian.xml
+++ b/testsuite/tck/src/test/resources/arquillian.xml
@@ -5,6 +5,8 @@
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
   <container qualifier="jbossas-managed" default="true">
     <configuration>
+        <!-- required for JDK 17 test run -->
+        <property name="javaVmArguments">-XX:-UseContainerSupport</property>
 <!--      <property name="jbossHome">target/jboss-as-7.1.1.Final</property>-->
 <!--      <property name="javaVmArguments">-Xmx512m -XX:MaxPermSize=128m-->
 <!--        -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y-->


### PR DESCRIPTION
Hopefully will fix the CI on JDK 17.